### PR TITLE
fix: chdir to parent cwd in child runner

### DIFF
--- a/packages/jest-runner-vscode/src/child/runner.ts
+++ b/packages/jest-runner-vscode/src/child/runner.ts
@@ -23,11 +23,16 @@ export async function run(): Promise<void> {
   )
 
   try {
-    const { PARENT_JEST_OPTIONS } = process.env
+    const { PARENT_JEST_OPTIONS, PARENT_CWD } = process.env
 
     if (!PARENT_JEST_OPTIONS) {
       throw new Error('PARENT_JEST_OPTIONS is not defined')
     }
+
+    if (PARENT_CWD) {
+      process.chdir(PARENT_CWD)
+    }
+
     const options = JSON.parse(PARENT_JEST_OPTIONS) as RemoteTestOptions
     const jestOptions = [
       ...options.args,


### PR DESCRIPTION
When using the runner on Windows, the cwd of the child process seems to be the directory where `code.exe` is located, rather than the directory where it was started (e.g. `./.vscode-test/vscode-win32-x64-archive-1.71.1`). On Linux and macOS, the cwd is correctly set to the directory from which Jest was launched (e.g. `.`).

To ensure consistency between platforms, this fix will always set the child process' cwd to the cwd of the parent.

This is mostly to fix an issue where `runCLI` within the child process cannot find a passed `--config` path since the cwd doesn't match what's expected by Jest. This can be replicated by running the following:

```shell
cd e2e/passing-tests
yarn jest --config ../passing-tests/jest.config.js
```

This will work on Linux and macOS, but will not work on Windows before this fix. After this fix, it will work correctly.